### PR TITLE
Audio call for Samsungs devices msm8916 chipset

### DIFF
--- a/src/com/android/server/telecom/CallAudioModeStateMachine.java
+++ b/src/com/android/server/telecom/CallAudioModeStateMachine.java
@@ -154,9 +154,13 @@ public class CallAudioModeStateMachine extends StateMachine {
         public void enter() {
             if (mIsInitialized) {
                 Log.i(LOG_TAG, "Abandoning audio focus: now UNFOCUSED");
+                boolean setRealcallAudioParams = SystemProperties
+                    .getBoolean("ro.telephony.samsung.realcall", false);
                 mAudioManager.abandonAudioFocusForCall();
                 mAudioManager.setMode(AudioManager.MODE_NORMAL);
-
+                if (setRealcallAudioParams) {
+                    mAudioManager.setParameters("realcall=off");
+                }
                 mMostRecentMode = AudioManager.MODE_NORMAL;
                 mCallAudioManager.setCallAudioRouteFocusState(CallAudioRouteStateMachine.NO_FOCUS);
             }
@@ -295,6 +299,8 @@ public class CallAudioModeStateMachine extends StateMachine {
             Log.i(LOG_TAG, "Audio focus entering SIM CALL state");
             boolean setMsimAudioParams = SystemProperties
                     .getBoolean("ro.multisim.set_audio_params", false);
+            boolean setRealcallAudioParams = SystemProperties
+                    .getBoolean("ro.telephony.samsung.realcall", false);
             Call call = mCallAudioManager.getForegroundCall();
 
             mAudioManager.requestAudioFocusForCall(AudioManager.STREAM_VOICE_CALL,
@@ -310,6 +316,9 @@ public class CallAudioModeStateMachine extends StateMachine {
                     mAudioManager.setParameters("phone_type=cp1");
                 } else if (phoneId == 1) {
                     mAudioManager.setParameters("phone_type=cp2");
+                }
+                if(setRealcallAudioParams){
+                    mAudioManager.setParameters("realcall=on");
                 }
             }
 


### PR DESCRIPTION
This only corrects audio on calls to msm8916 devices from samsung, it does not cause any effect on other devices, only on samsung msm8616 and it still needs to be configured on the device tree and system.prop.